### PR TITLE
More genericization in ConfigurableCombineFileRecordReader

### DIFF
--- a/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
+++ b/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
@@ -41,7 +41,8 @@ private[spark] class WholeTextFileInputFormat
       split: InputSplit,
       context: TaskAttemptContext): RecordReader[String, String] = {
 
-    val reader = new ConfigurableCombineFileRecordReader(split, context)
+    val reader =
+      new ConfigurableCombineFileRecordReader(split, context, classOf[WholeTextFileRecordReader])
     reader.setConf(getConf)
     reader
   }

--- a/core/src/main/scala/org/apache/spark/input/WholeTextFileRecordReader.scala
+++ b/core/src/main/scala/org/apache/spark/input/WholeTextFileRecordReader.scala
@@ -94,21 +94,23 @@ private[spark] class WholeTextFileRecordReader(
 
 /**
  * A [[org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader CombineFileRecordReader]]
- * that could pass Hadoop configuration to WholeTextFileRecordReader.
+ * that can pass Hadoop Configuration to [[org.apache.hadoop.conf.Configurable Configurable]]
+ * RecordReaders.
  */
-private[spark] class ConfigurableCombineFileRecordReader(
+private[spark] class ConfigurableCombineFileRecordReader[K, V](
     split: InputSplit,
-    context: TaskAttemptContext)
-  extends CombineFileRecordReader[String, String](
+    context: TaskAttemptContext,
+    recordReaderClass: Class[_ <: RecordReader[K, V] with HConfigurable])
+  extends CombineFileRecordReader[K, V](
     split.asInstanceOf[CombineFileSplit],
     context,
-    classOf[WholeTextFileRecordReader]
+    recordReaderClass
   ) with Configurable {
 
   override def initNextRecordReader(): Boolean = {
     val r = super.initNextRecordReader()
     if (r) {
-      this.curReader.asInstanceOf[WholeTextFileRecordReader].setConf(getConf)
+      this.curReader.asInstanceOf[HConfigurable].setConf(getConf)
     }
     r
   }


### PR DESCRIPTION
@davies Opening this as a PR against your PR, since this seemed easier than trying to describe this in a comment.

The main idea here is to remove the last traces of WholeTextFile-specific stuff from the ConfigurableCombineFileRecordReader class so that it just acts as plumbing for piping the `Configurable` configuration to the right place.

This seems clearer to me, since `ConfigurableCombineFileRecordReader` sounds like the name of a generic thing that's not WholeTextFiles-specific, so the hardcoding of some of those values was confusing to me.

Let me know what you think.  If this looks good, feel free to merge this into your PR (I've opened this against your PR branch).
